### PR TITLE
docs: add security definition with JWT to swagger docs

### DIFF
--- a/SherpaBackEnd/Program.cs
+++ b/SherpaBackEnd/Program.cs
@@ -4,6 +4,7 @@ using Amazon.Runtime;
 using Amazon.SimpleEmail;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using SherpaBackEnd.Email.Application;
 using SherpaBackEnd.Shared.Infrastructure.Persistence;
 using SherpaBackEnd.Shared.Infrastructure.Serializers;
@@ -33,7 +34,21 @@ builder.Services.Configure<DatabaseSettings>(
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "Sherpa", Version = "V1" });
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        In = ParameterLocation.Header,
+        Description = "Please enter token",
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        BearerFormat = "JWT",
+        Scheme = "bearer"
+    });
+
+    options.OperationFilter<AuthorizeOperationFilter>();
+});
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddRazorPages();

--- a/SherpaBackEnd/Shared/Infrastructure/Http/Docs/AuthorizeOperationFilter.cs
+++ b/SherpaBackEnd/Shared/Infrastructure/Http/Docs/AuthorizeOperationFilter.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+public class AuthorizeOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        ApplySwaggerAuthenticationToControllers(operation, context);
+        ApplySwaggerAuthenticationToMethods(operation, context);
+    }
+
+    private void ApplySwaggerAuthenticationToMethods(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.MethodInfo.GetCustomAttribute(typeof(AuthorizeAttribute)) != null)
+        {
+            AddSwaggerAuthenticationTo(operation);
+        }
+    }
+
+    private void ApplySwaggerAuthenticationToControllers(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.ApiDescription.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor &&
+            controllerActionDescriptor.ControllerTypeInfo.GetCustomAttribute(typeof(AuthorizeAttribute)) != null)
+        {
+            AddSwaggerAuthenticationTo(operation);
+        }
+    }
+
+    private void AddSwaggerAuthenticationTo(OpenApiOperation operation)
+    {
+        operation.Security = new List<OpenApiSecurityRequirement>
+        {
+            new()
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Updated the swagger docs with authentication information for endpoints. 

Created an operation filter for methods and controllers with the Authorization attribute.

This is to make it clearer which endpoints are protected with auth in the docs and to help us use Swagger to make authenticated requests